### PR TITLE
fix(RotationHelper): fix roll & lt bug

### DIFF
--- a/RotationHelper.lua
+++ b/RotationHelper.lua
@@ -35,16 +35,12 @@ function RotationHelper:GetYPRFromLUF(left, up, forward)
 		return yaw, pitch, roll
 	end
 
-	forward = forward * -1
-
-	local pitch = -asin(forward.y)
+	local pitch = asin(forward.y)
 
 	local yaw = atan(forward.x, forward.z)
 	local roll = 0
 
 	local y = Vec3(0,1,0)
-
-	forward = forward * -1
 
 	-- r0 is the right vector before pitch rotation
 	local r0 = Vec3(0,0,0)
@@ -105,7 +101,7 @@ end
 function RotationHelper:GetLUFFromYPR(yaw, pitch, roll)
 	-- Reference: http://planning.cs.uiuc.edu/node102.html
 
-	roll = -roll
+	pitch = -pitch
 
 	if yaw < pi then
 		yaw = -yaw

--- a/RotationHelper.lua
+++ b/RotationHelper.lua
@@ -35,11 +35,16 @@ function RotationHelper:GetYPRFromLUF(left, up, forward)
 		return yaw, pitch, roll
 	end
 
-	local pitch = asin(forward.y)
+	forward = forward * -1
+
+	local pitch = -asin(forward.y)
+
 	local yaw = atan(forward.x, forward.z)
 	local roll = 0
 
 	local y = Vec3(0,1,0)
+
+	forward = forward * -1
 
 	-- r0 is the right vector before pitch rotation
 	local r0 = Vec3(0,0,0)
@@ -86,13 +91,21 @@ function RotationHelper:GetYPRFromLUF(left, up, forward)
 		yaw = 2 * pi - yaw
 	end
 
+	if up.y < 0 then
+		roll = pi - roll
+	end
+
+	if roll > pi then
+		roll = -2 * pi + roll
+	end
+
 	return yaw, pitch, roll
 end
 
 function RotationHelper:GetLUFFromYPR(yaw, pitch, roll)
 	-- Reference: http://planning.cs.uiuc.edu/node102.html
 
-	pitch = -pitch
+	roll = -roll
 
 	if yaw < pi then
 		yaw = -yaw

--- a/RotationHelper.lua
+++ b/RotationHelper.lua
@@ -1,6 +1,6 @@
 class 'RotationHelper'
 
---YPR: yaw, pitch, roll (range: 0 - 2Pi)
+--YPR: yaw, pitch, roll
 --LUF: left, up, forward
 --LT: LinearTransform
 
@@ -83,7 +83,7 @@ function RotationHelper:GetYPRFromLUF(left, up, forward)
 	-- Update ranges:
 	-- yaw: (0, 2pi), clockwise, north = 0
 	-- pitch: (-pi/2, pi/2), horizon = 0, straight up = pi/2
-	-- roll: (-pi/2, pi/2), horizon = 0, full roll right = pi/2
+	-- roll: (-pi, pi), horizon = 0, full roll right = pi
 
 	if yaw < 0 then
 		yaw = -yaw

--- a/RotationHelper.lua
+++ b/RotationHelper.lua
@@ -78,8 +78,8 @@ function RotationHelper:GetYPRFromLUF(left, up, forward)
 
 	-- Update ranges:
 	-- yaw: (0, 2pi), clockwise, north = 0
-	-- pitch: (-pi/2, pi/2), horizon = 0, straight up = pi/2
-	-- roll: (-pi, pi), horizon = 0, full roll right = pi
+	-- pitch: (-pi, pi), horizon = 0, straight up = pi/2
+	-- roll: (-pi/2, pi/2), horizon = 0, full roll right = pi/2
 
 	if yaw < 0 then
 		yaw = -yaw
@@ -88,11 +88,19 @@ function RotationHelper:GetYPRFromLUF(left, up, forward)
 	end
 
 	if up.y < 0 then
-		roll = pi - roll
-	end
+		roll = -roll
 
-	if roll > pi then
-		roll = -2 * pi + roll
+		if pitch < 0 then
+			pitch = (pitch + pi) * -1
+		else
+			pitch = pi - pitch
+		end
+
+		if yaw < pi then
+			yaw = yaw + pi
+		else
+			yaw = yaw - pi
+		end
 	end
 
 	return yaw, pitch, roll


### PR DESCRIPTION
- fix roll (range: -pi to pi) (not sure if dice is using the same range)

We could also use `range: 0, 2*pi`.

I think there could also be the possibility that looking backwards affects the pitch and not the roll.
Atm if you look backwards we set the roll from 0 to pi. Instead we could also increase the range of the pitch. Instead of range: `-pi/2, pi/2`. it could be `-pi, pi`. (correct me if I'm wrong)
Not sure how dice did it. The best would be to have the same ranges as dice.

Just checked
```lua
ResourceManager:RegisterInstanceLoadHandler(Guid('DE2323F8-AE97-4402-A0F4-C49CACFEB8BB'), Guid('C82FC86A-AE50-4D60-8E80-1AA3613C6F83'), function(p_Instance)
    p_Instance = SoldierAimingSimulationData(p_Instance)
    p_Instance:MakeWritable()
    p_Instance.standPose.minimumPitch = -180.0
    p_Instance.standPose.maximumPitch = 180.0
    p_Instance.crouchPose.minimumPitch = -180.0
    p_Instance.crouchPose.maximumPitch = 180.0
    p_Instance.pronePose.minimumPitch = -180.0
    p_Instance.pronePose.maximumPitch = 180.0
    print("SoldierAimingSimulationData modified")
end)
```
Using this code I was able to look backwards with knife, and the pitch range goes from `-pi, pi` so this whole roll thing is wrong.